### PR TITLE
Fix cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ const options = {
   //Default is false.
   loose: true || false,
   //If the node version doesn't satisfy the engine version attempt to use the n pacakage manager to switch the current node version to compliant version.
-  //Defaul is false
+  //Default is false
   switch: true || false
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Options:
 Just require checker and invoke it.
 
 ```js
-var checker = require('node-version-checker/checker');
+var checker = require('node-version-checker');
 checker();
 ```
 
 Checker will throw an error if the versions don't match the rules. You can optionally pass in an options object to modify behavior:
 
 ```js
-const checker = require('node-version-checker/checker');
+const checker = require('node-version-checker');
 checker({loose: true, switch: false});
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,18 +34,35 @@ Options:
 ```
 
 ## Node Usage
-Just require checker and invoke it.
+Just require checker and then invoke it.
 
 ```js
-var checker = require('node-version-checker');
-checker();
+//Require syntax
+var checker = require('node-version-checker').default;
+//import syntax
+import checker from 'node-version-checker';
 ```
 
 Checker will throw an error if the versions don't match the rules. You can optionally pass in an options object to modify behavior:
 
 ```js
-const checker = require('node-version-checker');
+//Check with default options
+checker()
+//Check with options provided.
 checker({loose: true, switch: false});
+```
+
+### Node Options
+You can specify the following options when using through node:
+```js
+const options = {
+  //Check only that the current node version is greater the required engine version when set to true.
+  //Default is false.
+  loose: true || false,
+  //If the node version doesn't satisfy the engine version attempt to use the n pacakage manager to switch the current node version to compliant version.
+  //Defaul is false
+  switch: true || false
+}
 ```
 
 ## Package.json script

--- a/bin/nvc
+++ b/bin/nvc
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../dist/index');

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "node-version-checker",
   "version": "1.0.6",
   "description": "Checks the current version of node against the `engines` property of package.json",
-  "main": "dist/index.js",
+  "main": "dist/checker.js",
   "bin": {
-    "nvc": "dist/index.js"
+    "nvc": "bin/nvc"
   },
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-version-checker",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "description": "Checks the current version of node against the `engines` property of package.json",
   "main": "dist/checker.js",
   "bin": {


### PR DESCRIPTION
## Version 2.0.0
* Added a bash script to make the CLI function correctly.
* Fixed a problem with how importing worked for the node usage.
* Updated major version since this changes the consumption pattern

This has the following breaking changes:

### No Default Invocation
When consuming through node the check is not invoked on requiring the module, you have to invoke the function (which means you can now provide options)

#### Old Way
```js
var checker = require('node-version-checker');
//Check has already happened.
```
#### New Way
```js
var checker = require('node-version-checker').default;
//No check has happened yet.
checker();
//Now the check has happened.
```

### Require Must Specify Default
When consuming through node if you are using the require syntax you have to specify default.
#### Old Way
```js
//Old way that will no longer work.
var checker = require('node-version-checker');
checker();
```
#### New Way
```js
//New way that will work
var checker = require('node-version-checker').default
//Alternate way
var checker = require('node-version-checker');
checker.default();
//Using import you don't have to specify
import checker from 'node-version-checker';
```

### CLI
The CLI consumption pattern will now work without help.

### Related Issues
* https://github.com/gobold/node-version-checker/issues/2